### PR TITLE
add a shell script to run artemis in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,16 @@ be stopped):
 Now you can reconnect to artemis and run:
 
     docker exec -it artemis bash
-    cd artemis/source
-    CONFIG_FILE=/artemis/source/artemis/default_settings_docker.py python -m py.test artemis/tests
-
+    ./launch_artemis.sh
+    
+Note: you can pass parameters to artemis (the script parameters are forwarded to py.test).
+ 
+ You can thus for example:
+ 
+  * run only a test (by giving the path to the test file)
+  
+  * skip the loading of cities (--skip_cities)
+  
+  * skip the data loading (--skip_bina)
+  
+  * get more logs (-s)

--- a/factories/artemis/Dockerfile
+++ b/factories/artemis/Dockerfile
@@ -19,3 +19,10 @@ COPY unsecure_key.pub /root/.ssh/authorized_keys
 RUN chmod 644 /root/.ssh/authorized_keys
 
 RUN apt install -y vim
+
+# for artemis we'll need a virtualenv to install the requirements
+RUN apt-get install -y python-dev
+RUN pip install virtualenvwrapper
+RUN /bin/bash -c "source /usr/local/bin/virtualenvwrapper.sh && mkvirtualenv artemis"
+COPY launch_artemis.sh /launch_artemis.sh
+RUN chmod a+x /launch_artemis.sh

--- a/factories/artemis/launch_artemis.sh
+++ b/factories/artemis/launch_artemis.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# If some arguments are provided they are just given as is to pytest
+# else launch all artemis tests
+
+if [ "$#" -ne 0 ]; then
+additional_args=$@
+else
+additional_args=/artemis/source/artemis
+fi
+
+source /usr/local/bin/virtualenvwrapper.sh
+
+workon artemis
+
+pip install -r /artemis/source/requirements.txt
+
+CONFIG_FILE=/artemis/source/artemis/default_settings_docker.py python -m py.test $additional_args


### PR DESCRIPTION
now we can just run

`/launch_artemis.sh`

to run artemis

we can provide parameters to pytest like:
`./launch_artemis.sh /artemis/source/artemis/tests/bibus_test.py::TestBibus::test_stop_schedule --skip_cities --skip_bina -s`

Note: the image artemis in factories/artemis need to be rebuild

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia_image_manager/27)
<!-- Reviewable:end -->
